### PR TITLE
fix(calendar): add month to the key

### DIFF
--- a/src/components/apps/Calendar/Views/MonthView.tsx
+++ b/src/components/apps/Calendar/Views/MonthView.tsx
@@ -31,7 +31,7 @@ export const MonthView = () => {
             [css.today]: isToday,
             // [css.selected]: isSelected,
           })}
-          key={`day-${i}-${d}`}
+          key={`day-${i}-${d}-${selectedDate.getMonth()}`}
         >
           <div className={clsx({ [css.dateNumber]: true, [css.thisMonth]: isThisMonth })}>{d}</div>
         </div>


### PR DESCRIPTION
this prevents items showing as weekends on the previous/next month if they share the same number

same as https://github.com/PuruVJ/macos-web/pull/27